### PR TITLE
[SCR-683] feat: Change category in manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,7 @@
   "editor": "Marc Polycarpe",
   "vendor_link": "https://eticket.qiis.fr/",
   "categories": [
-    "others"
+    "finance"
   ],
   "fields": {
     "login": {


### PR DESCRIPTION
Replace category in manifest for the konnector to display in "employment and finance" category in the store